### PR TITLE
FIX URL scheme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,11 @@ RUN apt-get update && \
     zlib1g-dev
 
 # Clone everything, and setup the path.
-RUN git clone git://github.com/rbenv/rbenv.git /root/.rbenv && \
-    git clone git://github.com/rbenv/ruby-build.git /root/.rbenv/plugins/ruby-build && \
-    git clone git://github.com/nodenv/nodenv.git /root/.nodenv && \
-    git clone git://github.com/nodenv/node-build.git /root/.nodenv/plugins/node-build && \
-    git clone git://github.com/nodenv/nodenv-package-rehash.git /root/.nodenv/plugins/nodenv-package-rehash
+RUN git clone https://github.com/rbenv/rbenv.git /root/.rbenv && \
+    git clone https://github.com/rbenv/ruby-build.git /root/.rbenv/plugins/ruby-build && \
+    git clone https://github.com/nodenv/nodenv.git /root/.nodenv && \
+    git clone https://github.com/nodenv/node-build.git /root/.nodenv/plugins/node-build && \
+    git clone https://github.com/nodenv/nodenv-package-rehash.git /root/.nodenv/plugins/nodenv-package-rehash
 ENV PATH /root/.rbenv/shims:/root/.rbenv/bin:/root/.nodenv/shims:/root/.nodenv/bin:$PATH
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
The `git://` url scheme does not appear to work for me. I switched to the `https` scheme since that is what Github [recommends](https://help.github.com/articles/which-remote-url-should-i-use/) when cloning . 
